### PR TITLE
fixes problem timer delegates not being called while scrollview is scroling

### DIFF
--- a/Class/ZGCountDownTimer.m
+++ b/Class/ZGCountDownTimer.m
@@ -154,7 +154,7 @@ static NSMutableDictionary *_countDownTimersWithIdentifier;
 - (void)setupDefaultTimer {
     self.defaultTimer = [NSTimer timerWithTimeInterval:1.f target:self selector:@selector(timerUpdated:) userInfo:nil repeats:YES];
     [self.defaultTimer fire];
-    [[NSRunLoop currentRunLoop] addTimer:self.defaultTimer forMode:NSDefaultRunLoopMode];
+    [[NSRunLoop currentRunLoop] addTimer:self.defaultTimer forMode:NSRunLoopCommonModes];
 }
 
 - (void)notifyDelegate {


### PR DESCRIPTION
There is a issue that timer delegates are not being called while scrollview is scrolling or anything else is being done on main thread (main event loop).