### PR TITLE
Set self.timePassed before notifying delegates

### DIFF
--- a/Class/ZGCountDownTimer.m
+++ b/Class/ZGCountDownTimer.m
@@ -143,8 +143,8 @@ static NSMutableDictionary *_countDownTimersWithIdentifier;
         }
         else {
             NSTimeInterval newTimePassed = round(self.totalCountDownTime - [self.countDownCompleteDate timeIntervalSinceNow]);
-            [self notifySpecificDelegateMethods:newTimePassed];
             self.timePassed = newTimePassed;
+            [self notifySpecificDelegateMethods:newTimePassed];
         }
     }
 }


### PR DESCRIPTION
I think it would be good to set self.timePassed before calling the delegates so the delegates have the timer in an up to date state.
